### PR TITLE
Improved palette generation for bammer

### DIFF
--- a/bif.go
+++ b/bif.go
@@ -1,11 +1,11 @@
 package bg
 
 import (
-	"bytes"
+	//"bytes"
 	"io"
 	"os"
 
-	"code.google.com/p/lzma"
+	//"code.google.com/p/lzma"
 	//	"compress/zlib"
 	"encoding/binary"
 	"errors"
@@ -249,6 +249,7 @@ func RepackageBiff(keyFile io.ReadSeeker, bifIn io.ReadSeeker, filesPath string,
 	return nil
 }
 
+/*
 func ConvertToBIFL(r io.ReadSeeker, w io.WriteSeeker) error {
 	r.Seek(0, os.SEEK_SET)
 	w.Seek(0, os.SEEK_SET)
@@ -315,6 +316,7 @@ func ConvertToBIFL(r io.ReadSeeker, w io.WriteSeeker) error {
 	}
 	return nil
 }
+*/
 
 /*
 func MakeBiffFromDir(outputFile string, fileRoot string, files []string, biffId int) (int, error) {

--- a/wed.go
+++ b/wed.go
@@ -3,7 +3,7 @@ package bg
 import (
 	"encoding/binary"
 	"encoding/json"
-	"fmt"
+	//"fmt"
 	"image"
 	"image/draw"
 	"image/png"
@@ -110,6 +110,7 @@ func (wed *Wed) ToJson() (string, error) {
 	return string(bytes[0:]), nil
 }
 
+/*
 func (wed *Wed) ToJsonWed() (*JsonWed, error) {
 	jw := JsonWed{}
 	err := jw.ImportOverlays(wed)
@@ -121,6 +122,7 @@ func (wed *Wed) ToJsonWed() (*JsonWed, error) {
 
 	return &jw, nil
 }
+*/
 
 func (wed *Wed) UpdateOffsets() {
 


### PR DESCRIPTION
- fixed issue where opaque black would frequently be left out of palette (causing noticeable problems with shadows in icons)
- fixed issue where reserved colors would overwrite first elements of palette
- fixed early exit of palette quantize
- tweaked palette quantize to improve color selection
Also commented out some code not required by bammer that didn't compile as-is